### PR TITLE
Chore: update code quality pipeline to github actions marketplace

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,2 +1,0 @@
-name: "TrendTags Analysis"
-disable-default-queries: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,15 @@
-name: "CodeQL"
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "TrendTags Analysis"
 
 on:
   push:
@@ -8,10 +19,16 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+
 jobs:
   analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: 'ubuntu-latest'
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Updates the code quality actions to use default from GitHub marketplace. This negates the need for the codeql config files, and allow it to just be run with the workflows `yml` file. 

When combined with #52, this should ensure that all CI test pipelines for python and the CodeQL pipelines pass, resulting in that ever satisfying ✅

Also will stop spamming my phone "pipeline failed! pipeline failed! pipeline failed!" for no reason 😄 