### PR TITLE
Misc: update pyproject dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ optional = [
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py312']
 exclude = '''
 /(
     \.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,24 +5,14 @@ description = "A platform to generate relevant tags"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "certifi==2025.4.26",
-    "charset-normalizer==3.4.2",
-    "click==8.2.1",
-    "coverage==7.8.2",
-    "flask==3.1.1",
-    "idna==3.10",
-    "iniconfig==2.1.0",
-    "itsdangerous==2.2.0",
-    "jinja2==3.1.6",
-    "markupsafe==3.0.2",
-    "packaging==25.0",
-    "pluggy==1.6.0",
-    "pytest==8.4.0",
-    "pytest-cov==6.1.1",
-    "python-dotenv==0.19.0",
-    "requests==2.32.3",
-    "urllib3==2.4.0",
-    "werkzeug==2.0.1",
+    "flask>=3.1.1",
+    "python-dotenv>=1.1.0",
+    "requests>=2.32.3",
+]
+
+[project.optional-dependencies]
+optional = [
+    "ipykernel>=6.29.5",
 ]
 
 [tool.black]
@@ -37,3 +27,12 @@ exclude = '''
   | migrations
 )/
 '''
+
+[dependency-groups]
+dev = [
+    "black>=25.1.0",
+    "flake8>=7.2.0",
+    "pytest>=8.4.0",
+    "pytest-cov>=6.1.1",
+    "pytest-html>=4.1.1",
+]


### PR DESCRIPTION
Update dependencies in Pyproject to optimize for package managers - does not need to replicate requirements.txt file.

Ran program locally to confirm it still worked.

This should also close #74 by updating Black's target version, but we'll see.